### PR TITLE
Remove EdxRestApiClient usage in edx-enterprise-data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='django32-reporting'
+      if: matrix.python-version == '3.8' && matrix.toxenv=='django32-data'
       uses: codecov/codecov-action@v2
       with:
         flags: unittests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.2.5] - 2022-04-18
+---------------------
+  * Replace EdxRestApiClient with OAuthAPIClient.
+
 [4.2.4] - 2022-04-18
 ---------------------
   * Make API endpoints readonly.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ----------
 
 =========================
+[4.2.4] - 2022-04-18
+---------------------
+  * Make API endpoints readonly.
+
 [4.2.3] - 2022-03-16
 ---------------------
   * Remove error handling for rate limit exceptions for data API calls

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.2.4"
+__version__ = "4.2.5"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/__init__.py
+++ b/enterprise_data/__init__.py
@@ -2,6 +2,6 @@
 Enterprise data api application. This Django app exposes API endpoints used by enterprises.
 """
 
-__version__ = "4.2.3"
+__version__ = "4.2.4"
 
 default_app_config = "enterprise_data.apps.EnterpriseDataAppConfig"  # pylint: disable=invalid-name

--- a/enterprise_data/api/v0/views.py
+++ b/enterprise_data/api/v0/views.py
@@ -61,7 +61,7 @@ class EnterpriseViewSet(PermissionRequiredMixin, viewsets.ViewSet):
         return super().paginate_queryset(queryset)  # pylint: disable=no-member
 
 
-class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise course enrollments.
     """
@@ -232,7 +232,7 @@ class EnterpriseEnrollmentsViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
         return Response(content)
 
 
-class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise users.
     """
@@ -330,7 +330,7 @@ class EnterpriseUsersViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
     """
     View to manage enterprise learner completed course enrollments.
     """

--- a/enterprise_data/api/v1/views.py
+++ b/enterprise_data/api/v1/views.py
@@ -56,7 +56,7 @@ class EnterpriseViewSet(PermissionRequiredMixin, viewsets.ViewSet):
         return super().paginate_queryset(queryset)  # pylint: disable=no-member
 
 
-class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise course enrollments.
     """
@@ -250,7 +250,7 @@ class EnterpriseLearnerEnrollmentViewSet(EnterpriseViewSet, viewsets.ModelViewSe
         return Response(content)
 
 
-class EnterpriseLearnerViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+class EnterpriseLearnerViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
     """
     Viewset for routes related to Enterprise Learners.
     """
@@ -355,7 +355,7 @@ class EnterpriseLearnerViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSet, viewsets.ModelViewSet):
+class EnterpriseLearnerCompletedCoursesViewSet(EnterpriseViewSet, viewsets.ReadOnlyModelViewSet):
     """
     View to manage enterprise learner completed course enrollments.
     """

--- a/enterprise_data/clients.py
+++ b/enterprise_data/clients.py
@@ -4,10 +4,11 @@ Clients used to connect to other systems.
 
 
 import logging
+from urllib.parse import urljoin
 
 from edx_django_utils.cache import TieredCache
-from edx_rest_api_client.client import EdxRestApiClient
-from edx_rest_api_client.exceptions import HttpClientError, HttpServerError
+from edx_rest_api_client.client import OAuthAPIClient
+from requests.exceptions import RequestException
 from rest_framework.exceptions import NotFound, ParseError
 
 from django.conf import settings
@@ -18,23 +19,14 @@ DEFAULT_REPORTING_CACHE_TIMEOUT = 60 * 60 * 6  # 6 hours (Value is in seconds)
 LOGGER = logging.getLogger('enterprise_data')
 
 
-class EnterpriseApiClient(EdxRestApiClient):
+class EnterpriseApiClient(OAuthAPIClient):
     """
     The EnterpriseApiClient is used to communicate with the enterprise API endpoints in the LMS.
 
     This class is a sub-class of the edX Rest API Client
     (https://github.com/edx/edx-rest-api-client).
     """
-
-    API_BASE_URL = settings.LMS_BASE_URL + 'enterprise/api/v1/'
-
-    def __init__(self, jwt):
-        """
-        Initialize client with given jwt.
-        """
-        # If jwt token in request is already encoded into bytes decode it to avoid double encoding downstream
-        jwt = jwt.decode() if isinstance(jwt, bytes) else jwt
-        super().__init__(self.API_BASE_URL, jwt=jwt)
+    API_BASE_URL = urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/')
 
     def get_enterprise_learner(self, user):
         """
@@ -44,32 +36,34 @@ class EnterpriseApiClient(EdxRestApiClient):
         """
         try:
             querystring = {'username': user.username}
-            endpoint = getattr(self, 'enterprise-learner')
-            response = endpoint.get(**querystring)
-        except (HttpClientError, HttpServerError) as exc:
+            url = urljoin(self.API_BASE_URL, 'enterprise-learner')
+            response = self.get(url, params=querystring)
+            response.raise_for_status()
+            data = response.json()
+        except (RequestException) as exc:
             LOGGER.warning(
                 "[Data Overview Failure] Unable to retrieve Enterprise Customer Learner details. "
                 f"User: {user.username}, Exception: {exc}"
             )
-            raise exc
+            raise
 
-        if response.get('results', None) is None:
+        if data.get('results', None) is None:
             LOGGER.warning(
                 f"[Data Overview Failure] Enterprise Customer Learner details could not be found. User: {user.username}"
             )
             raise NotFound('Unable to process Enterprise Customer Learner details for user {}: No Results Found'
                            .format(user.username))
 
-        if response['count'] > 1:
+        if data['count'] > 1:
             LOGGER.warning(
                 f"[Data Overview Failure] Multiple Enterprise Customer Learners found. User: {user.username}"
             )
             raise ParseError(f'Multiple Enterprise Customer Learners found for user {user.username}')
 
-        if response['count'] == 0:
+        if data['count'] == 0:
             return None
 
-        return response['results'][0]
+        return data['results'][0]
 
     def get_enterprise_customer(self, user, enterprise_id):
         """
@@ -84,21 +78,22 @@ class EnterpriseApiClient(EdxRestApiClient):
         if cached_response.is_found:
             return cached_response.value
 
-        endpoint = getattr(self, 'enterprise-customer')
-        endpoint = endpoint(enterprise_id)
+        url = urljoin(self.API_BASE_URL, 'enterprise-customer')
 
         try:
-            response = endpoint.get()
-        except (HttpClientError, HttpServerError) as exc:
+            response = self.get(url)
+            response.raise_for_status()
+            data = response.json()
+        except (RequestException) as exc:
             LOGGER.warning(
                 "[Data Overview Failure] Unable to retrieve Enterprise Customer details. "
                 f"User: {user.username}, Enterprise: {enterprise_id}, Exception: {exc}"
             )
-            raise exc
+            raise
 
-        TieredCache.set_all_tiers(cache_key, response, DEFAULT_REPORTING_CACHE_TIMEOUT)
+        TieredCache.set_all_tiers(cache_key, data, DEFAULT_REPORTING_CACHE_TIMEOUT)
 
-        return response
+        return data
 
     def get_enterprise_and_update_session(self, request):
         """

--- a/enterprise_data/filters.py
+++ b/enterprise_data/filters.py
@@ -6,6 +6,7 @@ from logging import getLogger
 
 from rest_framework import filters
 
+from django.conf import settings
 from django.db.models import Q
 
 from enterprise_data.clients import EnterpriseApiClient
@@ -30,7 +31,11 @@ class FiltersMixin:
         """
         Make cached call to lms to get an enterprise data and update request session.
         """
-        enterprise_client = EnterpriseApiClient(request.auth)
+        enterprise_client = EnterpriseApiClient(
+            settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+        )
         __ = enterprise_client.get_enterprise_and_update_session(request)
 
 

--- a/enterprise_data/settings/test.py
+++ b/enterprise_data/settings/test.py
@@ -90,6 +90,10 @@ TEMPLATES = [
 
 LMS_BASE_URL = "http://localhost:8000/"
 
+BACKEND_SERVICE_EDX_OAUTH2_KEY = "analytics_api-backend-service-key"
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = "analytics_api-backend-service-secret"
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oauth2"
+
 ROOT_URLCONF = "enterprise_data.urls"
 
 SECRET_KEY = "insecure-secret-key"

--- a/enterprise_data/tests/test_clients.py
+++ b/enterprise_data/tests/test_clients.py
@@ -1,12 +1,14 @@
 """
 Tests for clients in enterprise_data.
 """
-from unittest import mock
-from unittest.mock import ANY, Mock
+from unittest.mock import Mock
+from urllib.parse import urljoin
 
-from edx_rest_api_client.exceptions import HttpClientError
+import responses
+from requests.exceptions import HTTPError
 from rest_framework.exceptions import NotFound, ParseError
 
+from django.conf import settings
 from django.test import TestCase
 
 from enterprise_data.clients import EnterpriseApiClient
@@ -35,50 +37,94 @@ class TestEnterpriseApiClient(TestCase):
         """
         Set up a mocked Enterprise API Client. Avoiding doing this in setup so we can test __init__.
         """
-        self.client = EnterpriseApiClient('test-token')  # pylint: disable=attribute-defined-outside-init
-        setattr(self.client, 'enterprise-learner', Mock(
-            get=self.mocked_get_endpoint
-        ))
+        self.client = EnterpriseApiClient(
+            settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_KEY,
+            settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
+        )  # pylint: disable=attribute-defined-outside-init
 
-        setattr(self.client, 'enterprise-customer', Mock(return_value=Mock(get=self.mocked_get_endpoint)))
+        responses.add(
+            responses.POST,
+            urljoin(settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL + '/', 'access_token'),
+            status=200,
+            json={
+                'access_token': 'test_access_token',
+                'expires_in': 10,
+            },
+            content_type='application/json'
+        )
 
-    @mock.patch('enterprise_data.clients.EdxRestApiClient.__init__')
-    def test_inits_client_with_jwt(self, mock_init):
-        EnterpriseApiClient('test-token')
-        mock_init.assert_called_with(ANY, jwt='test-token')
-
+    @responses.activate
     def test_get_enterprise_learner_returns_results_for_user(self):
         self.mock_client()
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         results = self.client.get_enterprise_learner(self.user)
-        self.mocked_get_endpoint.assert_called_with(username=self.user.username)
         assert results == self.api_response['results'][0]
 
+    @responses.activate
     def test_get_enterprise_learner_raises_exception_on_error(self):
-        self.mocked_get_endpoint = Mock(side_effect=HttpClientError)
         self.mock_client()
-        with self.assertRaises(HttpClientError):
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=404,
+            content_type='application/json'
+        )
+        with self.assertRaises(HTTPError):
             _ = self.client.get_enterprise_learner(self.user)
 
+    @responses.activate
     def test_get_enterprise_learner_returns_none_on_empty_results(self):
         self.mocked_get_endpoint = Mock(return_value={
             'count': 0,
             'results': []
         })
         self.mock_client()
+
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         results = self.client.get_enterprise_learner(self.user)
         self.assertIsNone(results)
 
+    @responses.activate
     def test_get_enterprise_learner_raises_not_found_on_no_results(self):
         self.mocked_get_endpoint = Mock(return_value={})
         self.mock_client()
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         with self.assertRaises(NotFound):
             _ = self.client.get_enterprise_learner(self.user)
 
+    @responses.activate
     def test_get_enterprise_learner_raises_parse_error_on_multiple_results(self):
         self.mocked_get_endpoint = Mock(return_value={
             'count': 2,
             'results': [{}, {}]
         })
         self.mock_client()
+        responses.add(
+            responses.GET,
+            urljoin(settings.LMS_BASE_URL + '/', 'enterprise/api/v1/enterprise-learner'),
+            json=self.mocked_get_endpoint(),
+            status=200,
+            content_type='application/json'
+        )
         with self.assertRaises(ParseError):
             _ = self.client.get_enterprise_learner(self.user)

--- a/enterprise_data/tests/test_views.py
+++ b/enterprise_data/tests/test_views.py
@@ -66,6 +66,11 @@ class TestEnterpriseEnrollmentsViewSet(JWTTestMixin, APITransactionTestCase):
         EnterpriseUser.objects.all().delete()
         EnterpriseEnrollment.objects.all().delete()
 
+    def test_options_request(self):
+        url = reverse('v0:enterprise-enrollments-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.options(url)
+        assert response.headers['Allow'] == 'GET, HEAD, OPTIONS'
+
     @staticmethod
     def _get_enrollments_expected_data(enrollments):
         """
@@ -881,6 +886,11 @@ class TestEnterpriseUsersViewSet(JWTTestMixin, APITransactionTestCase):
         EnterpriseUser.objects.all().delete()
         EnterpriseEnrollment.objects.all().delete()
 
+    def test_options_request(self):
+        url = reverse('v0:enterprise-users-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.options(url)
+        assert response.headers['Allow'] == 'GET, HEAD, OPTIONS'
+
     def test_viewset_no_query_params(self):
         """
         EnterpriseUserViewset should return all users if no filtering query
@@ -1408,6 +1418,11 @@ class TestEnterpriseLearnerCompletedCourses(JWTTestMixin, APITransactionTestCase
         super().tearDown()
         EnterpriseUser.objects.all().delete()
         EnterpriseEnrollment.objects.all().delete()
+
+    def test_options_request(self):
+        url = reverse('v0:enterprise-learner-completed-courses-list', kwargs={'enterprise_id': self.enterprise_id})
+        response = self.client.options(url)
+        assert response.headers['Allow'] == 'GET, HEAD, OPTIONS'
 
     def test_get_learner_completed_courses(self):
         """

--- a/enterprise_reporting/clients/__init__.py
+++ b/enterprise_reporting/clients/__init__.py
@@ -5,9 +5,9 @@ Clients used to access third party systems.
 import os
 from datetime import datetime
 from functools import wraps
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
-from edx_rest_api_client.client import EdxRestApiClient
+import requests
 
 
 class EdxOAuth2APIClient:
@@ -29,22 +29,27 @@ class EdxOAuth2APIClient:
         self.client_id = client_id or os.environ.get('LMS_OAUTH_KEY')
         self.client_secret = client_secret or os.environ.get('LMS_OAUTH_SECRET')
         self.expires_at = datetime.utcnow()
-        self.client = None
 
     def connect(self):
         """
         Connect to the REST API, authenticating with an access token retrieved with our client credentials.
         """
-        access_token, expires_at = EdxRestApiClient.get_oauth_access_token(
-            self.LMS_OAUTH_HOST + '/oauth2/access_token',
-            self.client_id,
-            self.client_secret,
-            'jwt'
+        response = requests.post(
+            urljoin(f'{self.LMS_OAUTH_HOST}/', 'oauth2/access_token'),
+            data={
+                'grant_type': 'client_credentials',
+                'client_id': self.client_id,
+                'client_secret': self.client_secret,
+                'token_type': 'jwt',
+            },
+            headers={
+                'User-Agent': 'enterprise_reporting',
+            },
+            timeout=(3.1, 5)
         )
-        self.client = EdxRestApiClient(
-            self.API_BASE_URL, append_slash=self.APPEND_SLASH, jwt=access_token,
-        )
-        self.expires_at = expires_at
+        data = response.json()
+        self.access_token = data['access_token']
+        self.expires_at = data['expires_in']
 
     def token_expired(self):
         """
@@ -92,24 +97,30 @@ class EdxOAuth2APIClient:
         """
         default_val = default if default is not self.DEFAULT_VALUE_SAFEGUARD else {}
         querystring = querystring or {}
+        path = f"{resource}{'/' + resource_id if resource_id else ''}{'/' + detail_resource if detail_resource else ''}"
+        url = urljoin(f'{self.API_BASE_URL}/', path)
+        headers = {'Authorization': "JWT {}".format(self.access_token)}
+        response = requests.get(
+            url,
+            headers=headers,
+            params=querystring
+        )
+        response.raise_for_status()
+        data = response.json()
 
-        endpoint = getattr(self.client, resource)
-        endpoint = getattr(self.client, resource)(resource_id) if resource_id else endpoint
-        endpoint = getattr(endpoint, detail_resource) if detail_resource else endpoint
-        response = endpoint.get(**querystring)
         if should_traverse_pagination:
-            results = traverse_pagination(response, endpoint)
-            response = {
+            results = traverse_pagination(data, self.access_token, url)
+            data = {
                 'count': len(results),
                 'next': None,
                 'previous': None,
                 'results': results,
             }
 
-        return response or default_val
+        return data or default_val
 
 
-def traverse_pagination(response, endpoint):
+def traverse_pagination(response, access_token, url):
     """
     Traverse a paginated API response.
 
@@ -118,7 +129,8 @@ def traverse_pagination(response, endpoint):
 
     Arguments:
         response (Dict): Current response dict from service API
-        endpoint (slumber Resource object): slumber Resource object from edx-rest-api-client
+        access_token (str): jwt token
+        url (str): API endpoint path
 
     Returns:
         list of dict.
@@ -129,8 +141,15 @@ def traverse_pagination(response, endpoint):
     next_page = response.get('next')
     while next_page:
         querystring = parse_qs(urlparse(next_page).query, True)
-        response = endpoint.get(**querystring)
-        results += response.get('results', [])
-        next_page = response.get('next')
+        headers = {'Authorization': "JWT {}".format(access_token)}
+        response = requests.get(
+            url,
+            headers=headers,
+            params=querystring
+        ).json
+        response.raise_for_status()
+        data = response.json()
+        results += data.get('results', [])
+        next_page = data.get('next')
 
     return results

--- a/enterprise_reporting/clients/enterprise.py
+++ b/enterprise_reporting/clients/enterprise.py
@@ -6,6 +6,7 @@ Client for connecting to the LMS Enterprise endpoints.
 
 import os
 from collections import OrderedDict
+from urllib.parse import urljoin
 
 from enterprise_reporting.clients import EdxOAuth2APIClient
 
@@ -14,9 +15,7 @@ class EnterpriseAPIClient(EdxOAuth2APIClient):
     """
     Client for connecting to the Enterprise API.
     """
-
-    API_BASE_URL = EdxOAuth2APIClient.LMS_ROOT_URL + '/enterprise/api/v1/'
-    APPEND_SLASH = True
+    API_BASE_URL = urljoin(EdxOAuth2APIClient.LMS_ROOT_URL + '/', 'enterprise/api/v1/')
 
     ENTERPRISE_REPORTING_ENDPOINT = 'enterprise_customer_reporting'
     ENTERPRISE_CUSTOMER_CATALOGS_ENDPOINT = 'enterprise_catalogs'
@@ -98,9 +97,7 @@ class EnterpriseDataApiClient(EdxOAuth2APIClient):
     Client for connecting to the Enterprise Data API.
     """
 
-    API_BASE_URL = os.getenv('ANALYTICS_API_URL', default='') + '/enterprise/api/v0'
-    APPEND_SLASH = True
-
+    API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'enterprise/api/v0')
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
     @EdxOAuth2APIClient.refresh_token
@@ -119,7 +116,7 @@ class EnterpriseDataV1ApiClient(EnterpriseDataApiClient):
     Client for connecting to the Enterprise Data V1 API.
     """
 
-    API_BASE_URL = os.getenv('ANALYTICS_API_URL', default='') + '/enterprise/api/v1'
+    API_BASE_URL =urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'enterprise/api/v1')
 
 
 class AnalyticsDataApiClient(EdxOAuth2APIClient):
@@ -127,9 +124,7 @@ class AnalyticsDataApiClient(EdxOAuth2APIClient):
     Client for connecting to the Analytics Data API.
     """
 
-    API_BASE_URL = os.getenv('ANALYTICS_API_URL', default='') + '/api/v0'
-    APPEND_SLASH = True
-
+    API_BASE_URL = urljoin(os.getenv('ANALYTICS_API_URL', default='') + '/', 'api/v0')
     PAGE_SIZE = os.getenv('PAGE_SIZE', default=1000)
 
     @EdxOAuth2APIClient.refresh_token


### PR DESCRIPTION
[OeX_Depr-52](https://youtrack.raccoongang.com/agiles/104-960/105-2571?issue=OeX_Depr-52) [Enterprise] Remove EdxRestApiClient usage in edx-enterprise-data
- An old EdxRestAPIClient was replaced with the OAuthAPIClient or requests.Session-based clients
- tests were fixed